### PR TITLE
add base architecture and initial packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+/.idea/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,4 +56,5 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+    implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
 }

--- a/app/src/main/java/com/baghdad/tudee/data/mapper/CategoryMapper.kt
+++ b/app/src/main/java/com/baghdad/tudee/data/mapper/CategoryMapper.kt
@@ -1,0 +1,22 @@
+package com.baghdad.tudee.data.mapper
+
+import com.baghdad.tudee.data.model.CategoryDto
+import com.baghdad.tudee.domain.entity.Category
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@OptIn(ExperimentalUuidApi::class)
+fun CategoryDto.toEntity():Category = Category(
+    id = Uuid.parse(this.id),
+    categoryTitle = this.categoryTitle,
+    taskCount = this.taskCount,
+    imageUri = this.imageUri
+)
+
+@OptIn(ExperimentalUuidApi::class)
+fun Category.toDto():CategoryDto = CategoryDto(
+    id = this.id.toString(),
+    imageUri = this.imageUri,
+    categoryTitle = this.categoryTitle,
+    taskCount = this.taskCount
+)

--- a/app/src/main/java/com/baghdad/tudee/data/mapper/TaskMapper.kt
+++ b/app/src/main/java/com/baghdad/tudee/data/mapper/TaskMapper.kt
@@ -1,0 +1,29 @@
+package com.baghdad.tudee.data.mapper
+
+import com.baghdad.tudee.data.model.TaskDto
+import com.baghdad.tudee.domain.entity.Task
+import kotlinx.datetime.LocalDate
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@OptIn(ExperimentalUuidApi::class)
+fun TaskDto.toEntity(): Task = Task(
+    id = Uuid.parse(this.id),
+    taskTitle = this.taskTitle,
+    description = this.description,
+    state = Task.State.valueOf(this.state),
+    date = LocalDate.parse(this.date),
+    categoryId = Uuid.parse(this.categoryId),
+    priority = Task.Priority.valueOf(this.priority)
+)
+
+@OptIn(ExperimentalUuidApi::class)
+fun Task.toDto():TaskDto = TaskDto(
+    id = this.id.toString(),
+    taskTitle = this.taskTitle,
+    description = this.description,
+    date = this.date.toString(),
+    priority = this.priority.toString(),
+    categoryId = this.categoryId.toString(),
+    state = this.state.toString()
+)

--- a/app/src/main/java/com/baghdad/tudee/data/model/CategoryDto.kt
+++ b/app/src/main/java/com/baghdad/tudee/data/model/CategoryDto.kt
@@ -1,11 +1,8 @@
 package com.baghdad.tudee.data.model
 
-import java.util.UUID
-
 data class CategoryDto(
-    val id: UUID,
+    val id: String,
     val categoryTitle: String,
     val taskCount: Int,
     val imageUri: String
-
 )

--- a/app/src/main/java/com/baghdad/tudee/data/model/CategoryDto.kt
+++ b/app/src/main/java/com/baghdad/tudee/data/model/CategoryDto.kt
@@ -1,0 +1,11 @@
+package com.baghdad.tudee.data.model
+
+import java.util.UUID
+
+data class CategoryDto(
+    val id: UUID,
+    val categoryTitle: String,
+    val taskCount: Int,
+    val imageUri: String
+
+)

--- a/app/src/main/java/com/baghdad/tudee/data/model/Priority.kt
+++ b/app/src/main/java/com/baghdad/tudee/data/model/Priority.kt
@@ -1,0 +1,7 @@
+package com.baghdad.tudee.data.model
+
+enum class Priority {
+    LOW,
+    MEDIUM,
+    HIGH
+}

--- a/app/src/main/java/com/baghdad/tudee/data/model/Priority.kt
+++ b/app/src/main/java/com/baghdad/tudee/data/model/Priority.kt
@@ -1,7 +1,0 @@
-package com.baghdad.tudee.data.model
-
-enum class Priority {
-    LOW,
-    MEDIUM,
-    HIGH
-}

--- a/app/src/main/java/com/baghdad/tudee/data/model/TaskDto.kt
+++ b/app/src/main/java/com/baghdad/tudee/data/model/TaskDto.kt
@@ -1,14 +1,11 @@
 package com.baghdad.tudee.data.model
 
-import java.time.LocalDate
-import java.util.UUID
-
 data class TaskDto(
-    val id: UUID,
+    val id: String,
     val taskTitle: String,
     val description: String,
-    val date: LocalDate,
-    val priority: Priority,
-    val categoryId: UUID,
-    val state: TaskState
+    val date: String,
+    val priority: String,
+    val categoryId: String,
+    val state: String
 )

--- a/app/src/main/java/com/baghdad/tudee/data/model/TaskDto.kt
+++ b/app/src/main/java/com/baghdad/tudee/data/model/TaskDto.kt
@@ -1,0 +1,14 @@
+package com.baghdad.tudee.data.model
+
+import java.time.LocalDate
+import java.util.UUID
+
+data class TaskDto(
+    val id: UUID,
+    val taskTitle: String,
+    val description: String,
+    val date: LocalDate,
+    val priority: Priority,
+    val categoryId: UUID,
+    val state: TaskState
+)

--- a/app/src/main/java/com/baghdad/tudee/data/model/TaskState.kt
+++ b/app/src/main/java/com/baghdad/tudee/data/model/TaskState.kt
@@ -1,7 +1,0 @@
-package com.baghdad.tudee.data.model
-
-enum class TaskState {
-    TODO,
-    IN_PROGRESS,
-    DONE
-}

--- a/app/src/main/java/com/baghdad/tudee/data/model/TaskState.kt
+++ b/app/src/main/java/com/baghdad/tudee/data/model/TaskState.kt
@@ -1,0 +1,7 @@
+package com.baghdad.tudee.data.model
+
+enum class TaskState {
+    TODO,
+    IN_PROGRESS,
+    DONE
+}

--- a/app/src/main/java/com/baghdad/tudee/data/service/CategoryServiceImpl.kt
+++ b/app/src/main/java/com/baghdad/tudee/data/service/CategoryServiceImpl.kt
@@ -1,0 +1,24 @@
+package com.baghdad.tudee.data.service
+
+import com.baghdad.tudee.domain.entity.Category
+import com.baghdad.tudee.domain.service.CategoryService
+import kotlinx.coroutines.flow.Flow
+import java.util.UUID
+
+class CategoryServiceImpl(): CategoryService {
+    override suspend fun getCategories(): Flow<List<Category>> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun createCategory(category: Category) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun editCategory(category: Category) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun deleteCategory(categoryId: UUID) {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/com/baghdad/tudee/data/service/TaskServiceImpl.kt
+++ b/app/src/main/java/com/baghdad/tudee/data/service/TaskServiceImpl.kt
@@ -1,0 +1,29 @@
+package com.baghdad.tudee.data.service
+
+import com.baghdad.tudee.domain.entity.Task
+import com.baghdad.tudee.domain.service.TaskService
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
+import java.util.UUID
+
+class TaskServiceImpl(): TaskService {
+    override suspend fun getTasksByCategory(categoryId: UUID): Flow<List<Task>> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getTasksByDate(date: LocalDate): Flow<List<Task>> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun createTask(task: Task) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun editTask(task: Task) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun deleteTask(taskId: UUID) {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/com/baghdad/tudee/data/service/ThemeServiceImpl.kt
+++ b/app/src/main/java/com/baghdad/tudee/data/service/ThemeServiceImpl.kt
@@ -1,9 +1,10 @@
 package com.baghdad.tudee.data.service
 
 import com.baghdad.tudee.domain.service.ThemeService
+import kotlinx.coroutines.flow.Flow
 
 class ThemeServiceImpl(): ThemeService {
-    override suspend fun isDarkTheme(): Boolean {
+    override suspend fun isDarkTheme(): Flow<Boolean> {
         TODO("Not yet implemented")
     }
 

--- a/app/src/main/java/com/baghdad/tudee/data/service/ThemeServiceImpl.kt
+++ b/app/src/main/java/com/baghdad/tudee/data/service/ThemeServiceImpl.kt
@@ -1,0 +1,13 @@
+package com.baghdad.tudee.data.service
+
+import com.baghdad.tudee.domain.service.ThemeService
+
+class ThemeServiceImpl(): ThemeService {
+    override suspend fun getTheme(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun setTheme(isDark: Boolean) {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/com/baghdad/tudee/data/service/ThemeServiceImpl.kt
+++ b/app/src/main/java/com/baghdad/tudee/data/service/ThemeServiceImpl.kt
@@ -3,7 +3,7 @@ package com.baghdad.tudee.data.service
 import com.baghdad.tudee.domain.service.ThemeService
 
 class ThemeServiceImpl(): ThemeService {
-    override suspend fun getTheme(): Boolean {
+    override suspend fun isDarkTheme(): Boolean {
         TODO("Not yet implemented")
     }
 

--- a/app/src/main/java/com/baghdad/tudee/domain/entity/Category.kt
+++ b/app/src/main/java/com/baghdad/tudee/domain/entity/Category.kt
@@ -1,5 +1,11 @@
 package com.baghdad.tudee.domain.entity
 
-data class Category(
-    val categoryTitle: String
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+data class Category @OptIn(ExperimentalUuidApi::class) constructor(
+    val id: Uuid,
+    val categoryTitle: String,
+    val taskCount: Int,
+    val imageUri: String
 )

--- a/app/src/main/java/com/baghdad/tudee/domain/entity/Category.kt
+++ b/app/src/main/java/com/baghdad/tudee/domain/entity/Category.kt
@@ -1,0 +1,5 @@
+package com.baghdad.tudee.domain.entity
+
+data class Category(
+    val categoryTitle: String
+)

--- a/app/src/main/java/com/baghdad/tudee/domain/entity/Task.kt
+++ b/app/src/main/java/com/baghdad/tudee/domain/entity/Task.kt
@@ -1,0 +1,5 @@
+package com.baghdad.tudee.domain.entity
+
+data class Task(
+    val taskTitle: String
+)

--- a/app/src/main/java/com/baghdad/tudee/domain/entity/Task.kt
+++ b/app/src/main/java/com/baghdad/tudee/domain/entity/Task.kt
@@ -1,5 +1,27 @@
 package com.baghdad.tudee.domain.entity
 
-data class Task(
-    val taskTitle: String
-)
+import kotlinx.datetime.LocalDate
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+data class Task @OptIn(ExperimentalUuidApi::class) constructor(
+    val id: Uuid,
+    val taskTitle: String,
+    val description: String,
+    val date: LocalDate,
+    val priority: Priority,
+    val categoryId: Uuid,
+    val state: State
+){
+    enum class State {
+        TODO,
+        IN_PROGRESS,
+        DONE
+    }
+
+    enum class Priority {
+        LOW,
+        MEDIUM,
+        HIGH
+    }
+}

--- a/app/src/main/java/com/baghdad/tudee/domain/service/CategoryService.kt
+++ b/app/src/main/java/com/baghdad/tudee/domain/service/CategoryService.kt
@@ -1,0 +1,13 @@
+package com.baghdad.tudee.domain.service
+
+import com.baghdad.tudee.domain.entity.Category
+import kotlinx.coroutines.flow.Flow
+import java.util.UUID
+
+interface CategoryService {
+
+
+    suspend fun getCategories(): Flow<List<Category>>
+    suspend fun createCategory(category: Category)
+    suspend fun editCategory(category: Category)
+    suspend fun deleteCategory(categoryId: UUID)}

--- a/app/src/main/java/com/baghdad/tudee/domain/service/TaskService.kt
+++ b/app/src/main/java/com/baghdad/tudee/domain/service/TaskService.kt
@@ -1,0 +1,16 @@
+package com.baghdad.tudee.domain.service
+
+import com.baghdad.tudee.domain.entity.Task
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
+import java.util.UUID
+
+interface TaskService {
+
+
+   suspend fun getTasksByCategory(categoryId: UUID): Flow<List<Task>>
+   suspend fun getTasksByDate(date: LocalDate): Flow<List<Task>>
+   suspend fun createTask(task: Task)
+   suspend fun editTask(task: Task)
+   suspend fun deleteTask(taskId: UUID)
+}

--- a/app/src/main/java/com/baghdad/tudee/domain/service/ThemeService.kt
+++ b/app/src/main/java/com/baghdad/tudee/domain/service/ThemeService.kt
@@ -1,0 +1,8 @@
+package com.baghdad.tudee.domain.service
+
+interface ThemeService {
+    suspend fun  getTheme(): Boolean
+    suspend fun setTheme(isDark: Boolean)
+
+
+}

--- a/app/src/main/java/com/baghdad/tudee/domain/service/ThemeService.kt
+++ b/app/src/main/java/com/baghdad/tudee/domain/service/ThemeService.kt
@@ -1,7 +1,9 @@
 package com.baghdad.tudee.domain.service
 
+import kotlinx.coroutines.flow.Flow
+
 interface ThemeService {
-    suspend fun  getTheme(): Boolean
+    suspend fun isDarkTheme(): Flow<Boolean>
     suspend fun setTheme(isDark: Boolean)
 
 


### PR DESCRIPTION
# 📦 Pull Request: `add base architecture (MVVM) and initial packages`

## 📝 Overview:
This PR sets up the base architecture of the project using the **MVVM** pattern.  
It introduces the initial structure for `data` and `domain` layers, including service interfaces, DTOs, and entities, laying the groundwork for future development.

---

## 📁 What's included:

### ✅ Data Layer:
**Packages added**:  
- `source`  
- `service`  
- `model`  

**DTO classes in `model`:**
- `CategoryDto`  
- `TaskDto`  

**Service implementations in `service`:**
- `ThemeServiceImpl`  
- `TaskServiceImpl`  
- `CategoryServiceImpl`  

---

### ✅ Domain Layer:
**Packages added**:  
- `service`  
- `entity`  

**Entities in `entity`:**
- `Category`  
- `Task`  

**Service interfaces in `service`:**
- `ThemeService`  
- `TaskService`  
- `CategoryService`  

---

## 🛠 Notes:
- All services and DTOs have been initialized with basic structure to allow further implementation.
- This setup ensures a **clean separation of concerns** between the `data` and `domain` layers as per **MVVM principles**.
