### PR TITLE
Fix/border in Tudee logo in splash screen

### DIFF
--- a/app/src/main/java/com/baghdad/tudee/ui/screens/SplashScreen/SplashScreen.kt
+++ b/app/src/main/java/com/baghdad/tudee/ui/screens/SplashScreen/SplashScreen.kt
@@ -1,7 +1,6 @@
 package com.baghdad.tudee.ui.screens.SplashScreen
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -12,7 +11,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.baghdad.tudee.R
-import com.baghdad.tudee.designSystem.theme.Theme
 import com.baghdad.tudee.ui.screens.OnboardingScreen.OnboardingBackground
 
 @Composable
@@ -30,11 +28,9 @@ fun SplashScreen(
                 modifier = Modifier
                     .width(122.dp)
                     .height(48.dp)
-                    .border(
-                        width = 1.dp,
-                        color = Theme.color.textColor.stroke,
-                    )
             )
         }
     }
 }
+
+


### PR DESCRIPTION
The Tudee logo was previously shown with a rectangular background on the splash screen, which affected the visual appearance.
This commit updates the splash screen to display the logo with a transparent background, removing the unwanted rectangle and improving the overall UI consistency.

![Uploading Screenshot_20250622_061833.png…]()


