### PR TITLE
Fix/set status bar icon color based on screen background not device theme

### DIFF
--- a/app/src/main/java/com/baghdad/tudee/designSystem/theme/TudeeTheme.kt
+++ b/app/src/main/java/com/baghdad/tudee/designSystem/theme/TudeeTheme.kt
@@ -7,6 +7,7 @@ import com.baghdad.tudee.designSystem.color.lightThemeColor
 import com.baghdad.tudee.designSystem.color.localTudeeColor
 import com.baghdad.tudee.designSystem.textStyle.localTudeeTextStyle
 import com.baghdad.tudee.designSystem.textStyle.tudeeTextStyle
+import com.baghdad.tudee.ui.utils.StatusBarTitleTheme
 
 
 @Composable
@@ -15,6 +16,8 @@ fun TudeeTheme(
     content: @Composable () -> Unit
 ) {
     val theme = if (isDarkTheme) darkThemeColor else lightThemeColor
+
+    StatusBarTitleTheme(isDarkTheme)
 
     CompositionLocalProvider(
         localTudeeColor provides theme,

--- a/app/src/main/java/com/baghdad/tudee/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/baghdad/tudee/ui/main/MainActivity.kt
@@ -7,12 +7,10 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.rememberNavController
 import com.baghdad.tudee.designSystem.theme.TudeeTheme

--- a/app/src/main/java/com/baghdad/tudee/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/baghdad/tudee/ui/main/MainActivity.kt
@@ -75,19 +75,3 @@ class MainActivity : ComponentActivity() {
         }
     }
 }
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    TudeeTheme {
-        Greeting("Android")
-    }
-}

--- a/app/src/main/java/com/baghdad/tudee/ui/utils/StatusBarTitleTheme.kt
+++ b/app/src/main/java/com/baghdad/tudee/ui/utils/StatusBarTitleTheme.kt
@@ -1,0 +1,17 @@
+package com.baghdad.tudee.ui.utils
+
+import android.app.Activity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowInsetsControllerCompat
+
+@Composable
+fun StatusBarTitleTheme(isDark: Boolean) {
+    val view = LocalView.current
+    val window = (view.context as Activity).window
+
+    SideEffect {
+        WindowInsetsControllerCompat(window!!, view).isAppearanceLightStatusBars = !isDark
+    }
+}


### PR DESCRIPTION
Issue #126 
Status bar colors should be depend on app theme and not device theme

![IMG_20250622_070159](https://github.com/user-attachments/assets/654015f8-3554-4da6-8321-d80490b05916)
![IMG_20250622_070227](https://github.com/user-attachments/assets/a7e567b0-2fcf-4e41-ad7a-b6abdb4f1a9e)
![IMG_20250622_070258](https://github.com/user-attachments/assets/ec7df90a-daeb-47ea-b260-fc1bcbf14a36)
![IMG_20250622_070315](https://github.com/user-attachments/assets/58ffb50d-bfd5-46ed-9396-ea159d05c288)
![IMG_20250622_070245](https://github.com/user-attachments/assets/4290d4fa-9dc9-4328-b801-f2e34a808013)
![IMG_20250622_070329](https://github.com/user-attachments/assets/f3d8a66b-f69b-4e13-8fe4-7de8487d0f2a)

- moved status bar icon color logic into TudeeTheme
- icons now change color based on app theme (dark/light)
- system theme no longer controls status bar appearance