### PR TITLE
 Fix/correctly move task to done state from bottom sheet

### DIFF
--- a/app/src/main/java/com/baghdad/tudee/ui/composable/taskDetailsBottomSheet/TaskActionsContainer.kt
+++ b/app/src/main/java/com/baghdad/tudee/ui/composable/taskDetailsBottomSheet/TaskActionsContainer.kt
@@ -1,6 +1,5 @@
 package com.baghdad.tudee.ui.composable.taskDetailsBottomSheet
 
-import android.R.attr.onClick
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -42,7 +41,7 @@ fun TaskActionsContainer(
                     shape = RoundedCornerShape(100)
                 )
                 .clip(RoundedCornerShape(100))
-                .noRippleClickable{
+                .noRippleClickable {
                     onEditClick()
                 },
             contentAlignment = Alignment.Center
@@ -64,7 +63,8 @@ fun TaskActionsContainer(
                     width = 1.dp,
                     color = Theme.color.textColor.stroke,
                     shape = RoundedCornerShape(100)
-                ).noRippleClickable{
+                )
+                .noRippleClickable {
                     onUpdateTaskStateClick()
                 },
             contentAlignment = Alignment.Center

--- a/app/src/main/java/com/baghdad/tudee/viewModel/homescreenViewModel/HomeScreenViewModel.kt
+++ b/app/src/main/java/com/baghdad/tudee/viewModel/homescreenViewModel/HomeScreenViewModel.kt
@@ -176,22 +176,24 @@ class HomeScreenViewModel(
     override fun moveTaskToDone(taskId: Long) {
         viewModelScope.launch {
             try {
-                taskService.getTasksByCategory(taskId)
-                    .collect { tasks ->
-                        tasks.find { it.id == taskId }?.let { task ->
-                            val updatedTask = task.copy(state = Task.State.DONE)
-                            taskService.editTask(updatedTask)
-                            _state.update { currentState ->
-                                currentState.copy(
-                                    inProgressTasks = _state.value.inProgressTasks - task,
-                                    doneTasks = _state.value.doneTasks + updatedTask,
-                                    todoTasks = _state.value.todoTasks - task,
-                                )
-                            }
-                        } ?: run {
-                            _state.update { it.copy(errorMessage = "Task not found") }
-                        }
+                val task = _state.value.inProgressTasks.find { it.id == taskId }
+                    ?: _state.value.todoTasks.find { it.id == taskId }
+
+                if (task != null) {
+                    val updatedTask = task.copy(state = Task.State.DONE)
+                    taskService.editTask(updatedTask)
+
+                    _state.update { currentState ->
+                        currentState.copy(
+                            inProgressTasks = currentState.inProgressTasks - task,
+                            todoTasks = currentState.todoTasks - task,
+                            doneTasks = currentState.doneTasks + updatedTask,
+                        )
                     }
+                } else {
+                    _state.update { it.copy(errorMessage = "Task not found") }
+                }
+
             } catch (e: Exception) {
                 _state.update { it.copy(errorMessage = "Failed to update task: ${e.message}") }
                 _state.value.errorMessage?.let {
@@ -206,7 +208,7 @@ class HomeScreenViewModel(
             try {
                 _state.value.inProgressTasks.find { it.id == taskId }?.let { task ->
                     taskService.editTask(
-                        task.copy(state = Task.State.DONE)
+                        task.copy(state = Task.State.TODO)
                     )
                 } ?: run {
                     _state.update { it.copy(errorMessage = "Task not found") }


### PR DESCRIPTION
Fixed an issue where tapping "Move to Done" in the bottom sheet didn’t update the task state due to incorrect use of getTasksByCategory. Now the task is retrieved from in-memory state and properly updated.

![done](https://github.com/user-attachments/assets/74f254d3-72eb-4c87-bb66-eb7afb19373b)
