### PR TITLE
Issue: Category Title Is Not Cleared After Being Added

### DIFF
--- a/app/src/main/java/com/baghdad/tudee/ui/screens/category/CategoryScreen.kt
+++ b/app/src/main/java/com/baghdad/tudee/ui/screens/category/CategoryScreen.kt
@@ -146,6 +146,7 @@ fun CategoryScreenContent(
                                 isPredefined = true
                             )
                         )
+                        text = ""
                     }
                 }
                 showAddNewCategoryDialog = false


### PR DESCRIPTION
in this pr 

When the user adds a category, the title field should be cleared after it is added.

https://github.com/user-attachments/assets/35a2d2d8-c879-462f-953d-66d18b5433d8

