### PR TITLE
Fix/#314 wrong empty tasks screen caption in CategoryTasksScreen

### DIFF
--- a/app/src/main/java/com/baghdad/tudee/ui/composable/TasksEmptyScreen.kt
+++ b/app/src/main/java/com/baghdad/tudee/ui/composable/TasksEmptyScreen.kt
@@ -26,7 +26,11 @@ import com.baghdad.tudee.designSystem.theme.Theme
 
 
 @Composable
-fun TasksEmptyScreen(modifier: Modifier = Modifier) {
+fun TasksEmptyScreen(
+    modifier: Modifier = Modifier,
+    canAdd: Boolean = true,
+    categoryTitle: String = ""
+) {
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -52,7 +56,9 @@ fun TasksEmptyScreen(modifier: Modifier = Modifier) {
                 ) {
                     TasksEmptyScreenTextBox(
                         modifier = Modifier
-                            .offset(y = -(40).dp, x = (24).dp)
+                            .offset(y = -(40).dp, x = (24).dp),
+                        canAdd = canAdd,
+                        categoryTitle = categoryTitle
                     )
                 }
                 Box(
@@ -68,7 +74,11 @@ fun TasksEmptyScreen(modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun TasksEmptyScreenTextBox(modifier: Modifier = Modifier) {
+private fun TasksEmptyScreenTextBox(
+    canAdd: Boolean,
+    categoryTitle: String,
+    modifier: Modifier = Modifier
+) {
     Box(
         modifier = modifier
             .offset(x = -(7).dp, y = (-15).dp)
@@ -88,16 +98,24 @@ fun TasksEmptyScreenTextBox(modifier: Modifier = Modifier) {
         Column(
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-            Text(
-                text = stringResource(R.string.no_tasks_yet),
-                style = Theme.typography.title.small,
-                color = Theme.color.textColor.body
-            )
-            Text(
-                text = stringResource(R.string.empty_tasks_desc),
-                style = Theme.typography.body.small,
-                color = Theme.color.textColor.hint
-            )
+            if(canAdd) {
+                Text(
+                    text = stringResource(R.string.no_tasks_yet),
+                    style = Theme.typography.title.small,
+                    color = Theme.color.textColor.body
+                )
+                Text(
+                    text = stringResource(R.string.empty_tasks_desc),
+                    style = Theme.typography.body.small,
+                    color = Theme.color.textColor.hint
+                )
+            } else {
+                Text(
+                    text = stringResource(R.string.no_tasks_in_category_template, categoryTitle),
+                    style = Theme.typography.title.small,
+                    color = Theme.color.textColor.body
+                )
+            }
         }
     }
 
@@ -122,7 +140,7 @@ private fun TasksEmptyScreenIllustration(modifier: Modifier = Modifier) {
             modifier = Modifier
                 .align(Alignment.BottomEnd)
                 .size(136.dp)
-                .offset( y = (3).dp)
+                .offset(y = (3).dp)
         )
         Icon(
             painter = painterResource(id = R.drawable.progress_indicator),

--- a/app/src/main/java/com/baghdad/tudee/ui/screens/categoryTasksScreen/components/CategoryTasksPager.kt
+++ b/app/src/main/java/com/baghdad/tudee/ui/screens/categoryTasksScreen/components/CategoryTasksPager.kt
@@ -31,7 +31,10 @@ import com.baghdad.tudee.ui.screens.categoryTasksScreen.CategoryTasksScreenUiSta
         }
 
         if (tasks.isEmpty()) {
-            TasksEmptyScreen()
+            TasksEmptyScreen(
+                canAdd = false,
+                categoryTitle = state.category.title
+            )
         } else {
             CategoryTasksList(tasks = tasks, state = state)
         }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -114,4 +114,5 @@
     <string name="edit_task_successfully">تم تعديل المهمة بنجاح</string>
     <string name="add_task_successfully">تم اضافة المهمة بنجاح</string>
     <string name="formatted_date">%1$s %2$s %3$s</string>
+    <string name="no_tasks_in_category_template">لا يوجد مهام في فئة %1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,5 +113,6 @@
     <string name="add_task_successfully">Add task successfully.</string>
     <string name="formatted_date">%1$s %2$s %3$s</string>
     <string name="skip">Skip</string>
+    <string name="no_tasks_in_category_template">No tasks in %1$s category!</string>
 
 </resources>


### PR DESCRIPTION
PR Content:
- Refactored `EmptyTasksScreen` caption to depend on whether user can add tasks in this screen or not. 
![Cannot add](https://github.com/user-attachments/assets/3febc394-5563-461c-8912-3f773ade5131)
![Can add](https://github.com/user-attachments/assets/a4cce294-d468-4d04-a5a9-86e5d2ca4448)
